### PR TITLE
Add Home view summary button translation

### DIFF
--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -91,6 +91,7 @@ LANGUAGES['ja'] = {
       "todays-total-sales": "本日の売上",
       "todays-visits": "本日の来訪者数",
       "todays-orders": "本日の注文数",
+      "view-summary": "概要を見る",
     },
 
     'titles': {


### PR DESCRIPTION
Found this hidden button that only displays on mobile web. Thus, I'd like to add a translation.
<img width="355" alt="screen shot 2017-07-08 at 12 13 11 pm" src="https://user-images.githubusercontent.com/1557529/27987114-f58f4954-63d6-11e7-88c6-5853d01cd240.png">
Current ☝️
This PR 👇 (I hope)
<img width="358" alt="screen shot 2017-07-08 at 12 13 48 pm" src="https://user-images.githubusercontent.com/1557529/27987115-f6dc9bb8-63d6-11e7-926f-f61ea1a0ce96.png">
